### PR TITLE
Update to 1.21

### DIFF
--- a/common/src/main/java/com/diontryban/transparent/client/TransparentConfigReloadListener.java
+++ b/common/src/main/java/com/diontryban/transparent/client/TransparentConfigReloadListener.java
@@ -47,7 +47,7 @@ public class TransparentConfigReloadListener implements PreparableReloadListener
             @NotNull Executor executor1
     ) {
         return CompletableFuture.supplyAsync(() -> null).thenCompose(preparationBarrier::wait).thenRun(() -> {
-            var configLocation = new ResourceLocation(Transparent.MOD_ID, Transparent.MOD_ID + ".json");
+            var configLocation = ResourceLocation.fromNamespaceAndPath(Transparent.MOD_ID, Transparent.MOD_ID + ".json");
             Gson gson = new Gson();
 
             if (resourceManager.getResource(configLocation).isPresent()) {
@@ -77,6 +77,6 @@ public class TransparentConfigReloadListener implements PreparableReloadListener
 
     @Override
     public @NotNull String getName() {
-        return new ResourceLocation(Transparent.MOD_ID, "config").toString();
+        return ResourceLocation.fromNamespaceAndPath(Transparent.MOD_ID, "config").toString();
     }
 }

--- a/common/src/main/java/com/diontryban/transparent/mixin/client/BeaconRendererMixin.java
+++ b/common/src/main/java/com/diontryban/transparent/mixin/client/BeaconRendererMixin.java
@@ -32,7 +32,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 @Mixin(BeaconRenderer.class)
 public abstract class BeaconRendererMixin implements BlockEntityRenderer<BeaconBlockEntity> {
     @Redirect(
-            method = "renderBeaconBeam(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;Lnet/minecraft/resources/ResourceLocation;FFJII[FFF)V",
+            method = "renderBeaconBeam(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;Lnet/minecraft/resources/ResourceLocation;FFJIIIFF)V",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/RenderType;beaconBeam(Lnet/minecraft/resources/ResourceLocation;Z)Lnet/minecraft/client/renderer/RenderType;")
     )
     private static RenderType redirectBeaconBeamInRenderBeaconBeam(ResourceLocation texture, boolean translucent) {

--- a/common/src/main/java/com/diontryban/transparent/mixin/client/PaintingRendererMixin.java
+++ b/common/src/main/java/com/diontryban/transparent/mixin/client/PaintingRendererMixin.java
@@ -86,7 +86,7 @@ public abstract class PaintingRendererMixin extends EntityRenderer<Painting> {
     ) {
         if (Transparent.CONFIG.painting && TransparentClient.isSpriteContentsTransparent(paintingSprite.contents())) {
             var accessor = ((TextureAtlasHolderAccessor) Minecraft.getInstance().getPaintingTextures());
-            var blankSprite = accessor.callGetSprite(new ResourceLocation(Transparent.MOD_ID, "blank"));
+            var blankSprite = accessor.callGetSprite(ResourceLocation.fromNamespaceAndPath(Transparent.MOD_ID, "blank"));
             // Only use blank sprite if it is on the same texture atlas as the painting sprite.
             if (blankSprite.atlasLocation().equals(paintingSprite.atlasLocation())) {
                 return blankSprite;

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'multiloader-loader'
-    id 'fabric-loom' version '1.6-SNAPSHOT'
+    id 'fabric-loom' version '1.7-SNAPSHOT'
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,9 @@
 # Important Notes:
 # - Every field you add must be added to the root build.gradle expandProps map.
-
 # Project
 version=21.0.0
 group=com.diontryban.transparent
 java_version=21
-
 # Common
 minecraft_version=1.21
 mod_name=Transparent
@@ -15,22 +13,19 @@ license=LGPL-3.0-or-later
 credits=Absolem Jackdaw [1.21 update]
 description=Allows resource packs to make certain entities support transparency.
 minecraft_version_range=[1.20.6, 1.21)
-ash_version=21.0.2-beta
-
+ash_version=20.6.2
 # Fabric
 fabric_version=0.102.0+1.21
 fabric_loader_version=0.16.7
 modmenu_version=10.0.0-beta.1
-
 # Forge
 forge_version=51.0.33
 forge_loader_version_range=[51,)
 forge_version_range=[51,)
-
 # NeoForge
 neoforge_version=21.0.167
 neoforge_loader_version_range=[4,)
-
 # Gradle
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,34 +2,34 @@
 # - Every field you add must be added to the root build.gradle expandProps map.
 
 # Project
-version=20.6.1
+version=21.0.0
 group=com.diontryban.transparent
 java_version=21
 
 # Common
-minecraft_version=1.20.6
+minecraft_version=1.21
 mod_name=Transparent
 mod_author=Trikzon
 mod_id=transparent
 license=LGPL-3.0-or-later
-credits=
+credits=Absolem Jackdaw [1.21 update]
 description=Allows resource packs to make certain entities support transparency.
 minecraft_version_range=[1.20.6, 1.21)
 ash_version=20.6.2-beta
 
 # Fabric
-fabric_version=0.98.0+1.20.6
-fabric_loader_version=0.15.11
+fabric_version=0.102.0+1.21
+fabric_loader_version=0.16.7
 modmenu_version=10.0.0-beta.1
 
 # Forge
-forge_version=50.0.8
-forge_loader_version_range=[50,)
-forge_version_range=[50,)
+forge_version=51.0.33
+forge_loader_version_range=[51,)
+forge_version_range=[51,)
 
 # NeoForge
-neoforge_version=20.6.48-beta
-neoforge_loader_version_range=[1,)
+neoforge_version=21.0.167
+neoforge_loader_version_range=[4,)
 
 # Gradle
 org.gradle.jvmargs=-Xmx3G

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ license=LGPL-3.0-or-later
 credits=Absolem Jackdaw [1.21 update]
 description=Allows resource packs to make certain entities support transparency.
 minecraft_version_range=[1.20.6, 1.21)
-ash_version=20.6.2-beta
+ash_version=21.0.2-beta
 
 # Fabric
 fabric_version=0.102.0+1.21

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
ash is kept in 20.6.2, as a Forge version does not exist.
Update ResourceLocation to use it's classes static methods.
Update verisoning in gradle properties
Update gradle wrapper to more recent version
Update fabric loom snapshot to more recent version
Update outdated methodname in a mixin